### PR TITLE
feat: add int lerp to the default lerp function

### DIFF
--- a/lib/src/property.dart
+++ b/lib/src/property.dart
@@ -134,10 +134,17 @@ class TimeKeyframeProperty<T> extends Equatable {
   List<Object?> get props => [name, lerp, keyframes];
 }
 
+int lerpInt(int a, int b, double t) {
+  return (a + (b - a) * t).toInt();
+}
+
 /// A default lerp function that support all base types (`Color`, `Size`, `Decoration`, ...).
 T defaultLerp<T>(T begin, T end, double time) {
   final dynamic b = begin;
   final dynamic e = end;
+  if (T == int) {
+    return lerpInt(b, e, time) as T;
+  }
   if (T == double) {
     return lerpDouble(b, e, time) as T;
   }


### PR DESCRIPTION
**[why add this PR]**
: because I want to do the alpha animation, which is ranged from 0 to 255. 
I knew I can use opacity, which is ranged from 0.0 to 1.0. But a support of int lerp might help many other scenarios, such as rotation degree (which is from 0 to 360)

